### PR TITLE
Add HVAC automation course outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Craft Pulse
 
 This repository contains resources for the Craft Pulse automation projects. The `contractor_assistant` directory holds a minimal example of a lead qualification and booking assistant built with Flask, Twilio, OpenAI, and Google Sheets.
+
+The `hvac_automation_course` directory provides an outline for a training course on implementing automation strategies in HVAC businesses.

--- a/hvac_automation_course/README.md
+++ b/hvac_automation_course/README.md
@@ -1,0 +1,45 @@
+# HVAC Business Automation Course
+
+This guide outlines a multi‑module course to help HVAC businesses use automation to grow and operate more efficiently. Each module includes key topics and suggestions for hands‑on projects.
+
+## Module 1: Understanding Automation Opportunities
+
+- Identify repetitive administrative tasks (dispatching, scheduling, invoicing)
+- Explore customer communications via SMS and email
+- Overview of workflow tools like Zapier and Make
+
+## Module 2: Lead Qualification Bots
+
+- Building SMS/chat assistants using services like Twilio
+- Connecting to language models for extracting lead details
+- Storing data in spreadsheets or a CRM
+
+## Module 3: Automated Scheduling
+
+- Integrating calendar APIs for appointment booking
+- Using reminders and confirmation messages
+- Handling rescheduling and cancellations automatically
+
+## Module 4: Technician Coordination
+
+- Dispatch notifications and route optimization
+- On‑site data capture for service notes
+- Syncing updates back to headquarters
+
+## Module 5: Sales and Follow‑Up Workflows
+
+- Automating quote creation and delivery
+- Tracking follow‑up tasks in a CRM
+- Triggering review requests after job completion
+
+## Module 6: Choosing the Right Tools
+
+- Comparing commercial platforms vs custom solutions
+- Evaluating costs, maintenance, and security
+- Planning incremental rollouts
+
+## Getting Started
+
+1. Review the modules and pick an area that addresses your biggest pain point.
+2. Prototype a simple workflow using no‑code tools before writing custom code.
+3. Measure time savings and refine the process based on technician and customer feedback.


### PR DESCRIPTION
## Summary
- document new training content for automation in the `hvac_automation_course` directory
- reference course content in the repo README

## Testing
- `python3 -m py_compile contractor_assistant/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ef22084a0832c8cd7c879eece7253