### PR TITLE
Add macOS ChatGPT popup app

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository contains resources for the Craft Pulse automation projects. The `contractor_assistant` directory holds a minimal example of a lead qualification and booking assistant built with Flask, Twilio, OpenAI, and Google Sheets.
 
 The `hvac_automation_course` directory provides an outline for a training course on implementing automation strategies in HVAC businesses.
+
+The `mac_chatgpt_popup` directory contains a small macOS menu bar app for sending quick prompts to ChatGPT.

--- a/mac_chatgpt_popup/README.md
+++ b/mac_chatgpt_popup/README.md
@@ -1,0 +1,31 @@
+# mac_chatgpt_popup
+
+This directory contains a small macOS menu bar application that lets you send quick prompts to ChatGPT. Clicking the status bar icon or pressing a global hotkey opens a text input popup. The contents are sent to OpenAI and the response is shown in the popup window.
+
+## Installation
+
+1. Ensure Python 3 is installed on your Mac.
+2. Install PyObjC and other dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Export your OpenAI API key so the application can authenticate:
+   ```bash
+   export OPENAI_API_KEY=sk-...
+   ```
+4. Run the application:
+   ```bash
+   python app.py
+   ```
+
+## Global Hotkey
+
+The app listens for `⌘`+`⇧`+`G` using `pynput`. On first run macOS will prompt for accessibility permissions. Grant your terminal (or Python) permission under System Settings → Privacy & Security → Accessibility.
+
+## Usage
+
+- Click the "💬" icon in the menu bar or press `⌘`+`⇧`+`G`.
+- Enter your question in the text field and press **Send** (or hit Return).
+- The response from OpenAI will appear in the lower pane.
+
+This is a simple example meant for experimentation. You can extend it with history, better error handling, or additional shortcuts.

--- a/mac_chatgpt_popup/app.py
+++ b/mac_chatgpt_popup/app.py
@@ -1,0 +1,108 @@
+import os
+import threading
+
+import openai
+from AppKit import (
+    NSApp,
+    NSApplication,
+    NSStatusBar,
+    NSVariableStatusItemLength,
+    NSMenu,
+    NSMenuItem,
+    NSWindow,
+    NSTextField,
+    NSButton,
+    NSTextView,
+    NSMakeRect,
+    NSBackingStoreBuffered,
+    NSTitledWindowMask,
+)
+from Foundation import NSObject
+from PyObjCTools import AppHelper
+from pynput import keyboard
+
+
+class AppDelegate(NSObject):
+    def applicationDidFinishLaunching_(self, notification):
+        self.create_status_item()
+        self.create_window()
+        self.start_hotkey_listener()
+
+    # Status bar
+    def create_status_item(self):
+        status_bar = NSStatusBar.systemStatusBar()
+        self.status_item = status_bar.statusItemWithLength_(NSVariableStatusItemLength)
+        self.status_item.setTitle_("💬")
+        menu = NSMenu.alloc().init()
+        item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Ask ChatGPT", "openWindow:", ""
+        )
+        menu.addItem_(item)
+        quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Quit", "terminate:", "q"
+        )
+        menu.addItem_(quit_item)
+        self.status_item.setMenu_(menu)
+
+    # Hotkey
+    def start_hotkey_listener(self):
+        listener = keyboard.GlobalHotKeys({"<cmd>+<shift>+g": self.openWindow})
+        listener.start()
+        self.listener = listener
+
+    # UI
+    def create_window(self):
+        rect = ((200.0, 200.0), (400.0, 200.0))
+        style = NSTitledWindowMask
+        self.window = NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            rect, style, NSBackingStoreBuffered, False
+        )
+        self.window.setTitle_("ChatGPT Prompt")
+
+        self.input_field = NSTextField.alloc().initWithFrame_(NSMakeRect(20, 150, 360, 24))
+        self.output_view = NSTextView.alloc().initWithFrame_(NSMakeRect(20, 20, 360, 120))
+        self.output_view.setEditable_(False)
+
+        button = NSButton.alloc().initWithFrame_(NSMakeRect(300, 170, 80, 24))
+        button.setTitle_("Send")
+        button.setTarget_(self)
+        button.setAction_("sendPrompt:")
+
+        self.window.contentView().addSubview_(self.input_field)
+        self.window.contentView().addSubview_(self.output_view)
+        self.window.contentView().addSubview_(button)
+
+    def openWindow(self):
+        self.window.makeKeyAndOrderFront_(None)
+        NSApp.activateIgnoringOtherApps_(True)
+
+    def openWindow_(self, sender):
+        self.openWindow()
+
+    def sendPrompt_(self, sender):
+        prompt = self.input_field.stringValue()
+        if not prompt:
+            return
+        thread = threading.Thread(target=self.call_openai, args=(prompt,))
+        thread.start()
+
+    def call_openai(self, prompt):
+        openai.api_key = os.environ.get("OPENAI_API_KEY")
+        try:
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = resp["choices"][0]["message"]["content"]
+        except Exception as e:
+            text = f"Error: {e}"
+        self.output_view.performSelectorOnMainThread_withObject_waitUntilDone_(
+            "setString:", text, False
+        )
+
+
+if __name__ == "__main__":
+    app = NSApplication.sharedApplication()
+    delegate = AppDelegate.alloc().init()
+    app.setDelegate_(delegate)
+    AppHelper.runEventLoop()

--- a/mac_chatgpt_popup/requirements.txt
+++ b/mac_chatgpt_popup/requirements.txt
@@ -1,0 +1,3 @@
+openai
+pyobjc
+pynput


### PR DESCRIPTION
## Summary
- document a new Mac menu bar ChatGPT app
- implement `mac_chatgpt_popup` PyObjC app that uses OpenAI API
- list requirements for the Mac app

## Testing
- `python -m py_compile mac_chatgpt_popup/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687499aec0b0832ca6518343ea5d4b44